### PR TITLE
feat(tui): Conductor-like workspace layout with multi-chat and worktree sidebar

### DIFF
--- a/apps/tui/src/components/DynamicInput.tsx
+++ b/apps/tui/src/components/DynamicInput.tsx
@@ -4,6 +4,7 @@ import { useCommandHistory } from "../hooks/useCommandHistory";
 import { usePaste } from "../hooks/usePaste";
 import { OneDarkPro } from "../styles/theme";
 import type { QuestionData } from "../types";
+import { ModeIndicator } from "./ModeIndicator";
 import { QuestionPanel, calculateQuestionHeight } from "./QuestionPanel";
 import { type CommandSuggestion, SuggestionsPanel } from "./SuggestionsPanel";
 
@@ -184,8 +185,9 @@ export function DynamicInput({
         return;
       }
 
-      // Tab or Enter to accept suggestion when suggestions are showing
-      if (event.name === "tab" || event.name === "return") {
+      // Enter to accept suggestion when suggestions are showing
+      // (Tab is repurposed for focus zone cycling at the App level)
+      if (event.name === "return") {
         event.preventDefault?.(); // Prevent default behavior
         const suggestion = filteredSuggestions[selectedSuggestion];
         if (suggestion) {
@@ -311,6 +313,7 @@ export function DynamicInput({
         opacity={rawInputMode ? 0.5 : 1.0}
       >
         <box flexDirection="row" width="100%">
+          {!rawInputMode && <ModeIndicator mode={mode} />}
           <text
             fg={rawInputMode ? OneDarkPro.ui.border : OneDarkPro.syntax.green}
           >

--- a/apps/tui/src/components/ModeIndicator.tsx
+++ b/apps/tui/src/components/ModeIndicator.tsx
@@ -1,0 +1,43 @@
+/**
+ * ModeIndicator Component
+ * Inline badge showing current mode (PLAN/BUILD/REVIEW) with color coding.
+ * Displayed in the input area before the prompt character.
+ */
+
+import { OneDarkPro } from "../styles/theme";
+
+interface ModeIndicatorProps {
+  mode: "none" | "plan" | "build" | "review";
+}
+
+function getModeConfig(mode: ModeIndicatorProps["mode"]): {
+  label: string;
+  color: string;
+} | null {
+  switch (mode) {
+    case "plan":
+      return { label: "PLAN", color: "#3B82F6" };
+    case "build":
+      return { label: "BUILD", color: "#F59E0B" };
+    case "review":
+      return { label: "REVIEW", color: "#10B981" };
+    default:
+      return null;
+  }
+}
+
+export function ModeIndicator({ mode }: ModeIndicatorProps) {
+  const config = getModeConfig(mode);
+
+  if (!config) {
+    return (
+      <text fg={OneDarkPro.foreground.comment}>{"⇧Tab:mode "}</text>
+    );
+  }
+
+  return (
+    <text fg={config.color} bold>
+      {`[${config.label}] `}
+    </text>
+  );
+}

--- a/apps/tui/src/components/OutputPanel.tsx
+++ b/apps/tui/src/components/OutputPanel.tsx
@@ -16,7 +16,7 @@ interface OutputPanelProps {
   height: number;
   lines: OutputLineType[];
   isRunning?: boolean;
-  mode?: "none" | "plan" | "build";
+  mode?: "none" | "plan" | "build" | "review";
   modeColor?: string;
   /** Enable auto-scroll to bottom when new content is added (default: true) */
   stickyScroll?: boolean;

--- a/apps/tui/src/components/StatusBar.tsx
+++ b/apps/tui/src/components/StatusBar.tsx
@@ -12,6 +12,12 @@ interface StatusBarProps {
   isRunning: boolean;
   inputFocused?: boolean;
   workspaceRoot?: string;
+  /** Current git branch name */
+  branchName?: string;
+  /** Current mode */
+  mode?: "none" | "plan" | "build" | "review";
+  /** Current focus zone */
+  focusZone?: "sidebar" | "tabs" | "main";
   /** Worker connection status */
   workerStatus?: WorkerStatus;
   /** Number of active Slack sessions on this worker */
@@ -34,6 +40,9 @@ export function StatusBar({
   isRunning,
   inputFocused = false,
   workspaceRoot,
+  branchName,
+  mode = "none",
+  focusZone,
   workerStatus,
   workerSessions = 0,
   workerMode = false,
@@ -136,11 +145,11 @@ export function StatusBar({
       helpHint = "q Exit  •  Ctrl+C Quit";
     }
   } else if (inputFocused) {
-    helpHint = "Enter execute  •  Tab complete  •  Esc unfocus  •  Ctrl+C quit";
+    helpHint = "Enter execute  •  Esc unfocus  •  ⇧Tab mode  •  Ctrl+C quit";
   } else if (isRunning) {
-    helpHint = "Ctrl+G scroll bottom  •  Ctrl+C quit";
+    helpHint = "Tab focus  •  ⇧Tab mode  •  Ctrl+C interrupt";
   } else {
-    helpHint = "/ input  •  ? help  •  Esc back  •  Ctrl+C quit";
+    helpHint = "/ input  •  Tab focus  •  ⇧Tab mode  •  ? help";
   }
 
   return (
@@ -191,10 +200,16 @@ export function StatusBar({
           <>
             {/* Normal mode: Show execution status */}
             <text fg={statusColor}>{statusText}</text>
-            {workspaceRoot && (
+            {branchName && (
               <>
                 <text fg={OneDarkPro.foreground.muted}> • </text>
-                <text fg={OneDarkPro.syntax.cyan}>📁 {workspaceName}</text>
+                <text fg={OneDarkPro.syntax.magenta}>{branchName}</text>
+              </>
+            )}
+            {!branchName && workspaceRoot && (
+              <>
+                <text fg={OneDarkPro.foreground.muted}> • </text>
+                <text fg={OneDarkPro.syntax.cyan}>{workspaceName}</text>
               </>
             )}
             {workerDisplay && (

--- a/apps/tui/src/components/StreamingIndicator.tsx
+++ b/apps/tui/src/components/StreamingIndicator.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
 import { OneDarkPro } from "../styles/theme";
 
 interface StreamingIndicatorProps {
-  mode?: "plan" | "build" | "none";
+  mode?: "plan" | "build" | "review" | "none";
 }
 
 export function StreamingIndicator({ mode = "none" }: StreamingIndicatorProps) {

--- a/apps/tui/src/components/TabBar.tsx
+++ b/apps/tui/src/components/TabBar.tsx
@@ -1,0 +1,179 @@
+/**
+ * TabBar Component
+ * Horizontal chat tabs across the top of the main area.
+ * Shows one tab per chat with mode color, running indicator, and question badge.
+ */
+
+import { useKeyboard } from "@opentui/react";
+import { OneDarkPro } from "../styles/theme";
+
+export interface TabInfo {
+  id: string;
+  label: string;
+  mode: "none" | "plan" | "build" | "review";
+  isRunning: boolean;
+  hasQuestion: boolean;
+}
+
+interface TabBarProps {
+  width: number;
+  tabs: TabInfo[];
+  activeTabId: string | null;
+  focused: boolean;
+  selectedIndex: number;
+  onSelectTab: (id: string) => void;
+  onCloseTab: (id: string) => void;
+  onNewTab: () => void;
+  onNavigate: (index: number) => void;
+}
+
+function getModeColor(mode: TabInfo["mode"]): string {
+  switch (mode) {
+    case "plan":
+      return "#3B82F6"; // blue-500
+    case "build":
+      return "#F59E0B"; // amber-500
+    case "review":
+      return "#10B981"; // green-500
+    default:
+      return OneDarkPro.foreground.muted;
+  }
+}
+
+function getModePrefix(mode: TabInfo["mode"]): string {
+  switch (mode) {
+    case "plan":
+      return "plan";
+    case "build":
+      return "build";
+    case "review":
+      return "review";
+    default:
+      return "";
+  }
+}
+
+export function TabBar({
+  width,
+  tabs,
+  activeTabId,
+  focused,
+  selectedIndex,
+  onSelectTab,
+  onCloseTab,
+  onNewTab,
+  onNavigate,
+}: TabBarProps) {
+  // Keyboard handling when tabs zone is focused
+  useKeyboard((event) => {
+    if (!focused) return;
+
+    if (event.name === "left" || event.sequence === "h") {
+      onNavigate(Math.max(0, selectedIndex - 1));
+      return;
+    }
+    if (event.name === "right" || event.sequence === "l") {
+      // +1 for the [+] button
+      onNavigate(Math.min(tabs.length, selectedIndex + 1));
+      return;
+    }
+    if (event.name === "return") {
+      if (selectedIndex === tabs.length) {
+        // [+] button selected
+        onNewTab();
+      } else {
+        const tab = tabs[selectedIndex];
+        if (tab) onSelectTab(tab.id);
+      }
+      return;
+    }
+    if (event.sequence === "t") {
+      onNewTab();
+      return;
+    }
+    if (event.sequence === "w") {
+      const tab = tabs[selectedIndex];
+      if (tab) onCloseTab(tab.id);
+      return;
+    }
+  });
+
+  // Calculate max width per tab
+  const newButtonWidth = 5; // " [+] "
+  const availableWidth = width - newButtonWidth - 1;
+  const maxTabWidth = tabs.length > 0
+    ? Math.max(12, Math.floor(availableWidth / tabs.length))
+    : availableWidth;
+
+  const truncate = (text: string, maxLen: number) => {
+    return text.length > maxLen ? `${text.substring(0, maxLen - 1)}…` : text;
+  };
+
+  return (
+    <box
+      width={width}
+      height={1}
+      flexDirection="row"
+      backgroundColor={OneDarkPro.background.secondary}
+    >
+      {tabs.map((tab, i) => {
+        const isActive = tab.id === activeTabId;
+        const isSelectedInFocus = focused && i === selectedIndex;
+        const modeColor = getModeColor(tab.mode);
+        const prefix = getModePrefix(tab.mode);
+
+        // Build tab label
+        let displayLabel = prefix ? `${prefix}: ${tab.label}` : tab.label;
+        const indicators = [
+          tab.isRunning ? "●" : "",
+          tab.hasQuestion ? "!" : "",
+        ]
+          .filter(Boolean)
+          .join("");
+        if (indicators) {
+          displayLabel = `${indicators} ${displayLabel}`;
+        }
+
+        displayLabel = truncate(displayLabel, maxTabWidth - 4); // 4 for "[ " + " ]"
+
+        return (
+          <box key={tab.id} flexDirection="row">
+            <text
+              fg={isActive ? modeColor : OneDarkPro.foreground.muted}
+              bg={
+                isSelectedInFocus
+                  ? OneDarkPro.background.highlight
+                  : isActive
+                    ? OneDarkPro.background.primary
+                    : undefined
+              }
+              bold={isActive}
+              underline={isActive && focused}
+            >
+              {` ${displayLabel} `}
+            </text>
+            {i < tabs.length - 1 && (
+              <text fg={OneDarkPro.ui.border}>│</text>
+            )}
+          </box>
+        );
+      })}
+
+      {/* New tab button */}
+      <text
+        fg={
+          focused && selectedIndex === tabs.length
+            ? OneDarkPro.syntax.green
+            : OneDarkPro.foreground.muted
+        }
+        bg={
+          focused && selectedIndex === tabs.length
+            ? OneDarkPro.background.highlight
+            : undefined
+        }
+      >
+        {" [+]"}
+      </text>
+    </box>
+  );
+}

--- a/apps/tui/src/components/WorktreeSidebar.tsx
+++ b/apps/tui/src/components/WorktreeSidebar.tsx
@@ -1,0 +1,275 @@
+/**
+ * WorktreeSidebar Component
+ * Tree view showing worktrees with nested Linear tasks.
+ * Replaces the old task-only Sidebar for the Conductor-like layout.
+ */
+
+import { useKeyboard } from "@opentui/react";
+import { OneDarkPro } from "../styles/theme";
+import type { Task } from "../types";
+import type { WorktreeInfo } from "../services/WorktreeService";
+import { getTaskStatus } from "../utils/taskHelpers";
+
+interface WorktreeSidebarProps {
+  width: number;
+  height: number;
+  worktrees: WorktreeInfo[];
+  tasksPerWorktree: Map<string, Task[]>;
+  activeWorktreePath: string | null;
+  focused: boolean;
+  selectedIndex: number;
+  expandedPaths: Set<string>;
+  onSelect: (worktreePath: string) => void;
+  onCreateNew: () => void;
+  onNavigate: (index: number) => void;
+  onToggleExpand: (worktreePath: string) => void;
+}
+
+interface FlatItem {
+  type: "worktree" | "task" | "new-button";
+  worktreePath?: string;
+  task?: Task;
+  label: string;
+  indent: number;
+}
+
+function buildFlatList(
+  worktrees: WorktreeInfo[],
+  expandedPaths: Set<string>,
+  tasksPerWorktree: Map<string, Task[]>,
+): FlatItem[] {
+  const items: FlatItem[] = [];
+
+  for (const wt of worktrees) {
+    const displayName = wt.isMain
+      ? `main (${wt.branch})`
+      : wt.epicIdentifier || wt.branch.replace("clive/", "");
+
+    items.push({
+      type: "worktree",
+      worktreePath: wt.path,
+      label: displayName,
+      indent: 0,
+    });
+
+    if (expandedPaths.has(wt.path)) {
+      const tasks = tasksPerWorktree.get(wt.path) ?? [];
+      for (const task of tasks) {
+        items.push({
+          type: "task",
+          worktreePath: wt.path,
+          task,
+          label: task.title,
+          indent: 1,
+        });
+      }
+    }
+  }
+
+  items.push({
+    type: "new-button",
+    label: "New worktree",
+    indent: 0,
+  });
+
+  return items;
+}
+
+function getStatusIcon(task: Task): string {
+  const status = getTaskStatus(task);
+  if (status === "in_progress") return "⚡";
+  if (status === "blocked") return "⊗";
+  if (status === "completed") return "✓";
+  return "○";
+}
+
+function getStatusColor(task: Task): string {
+  const status = getTaskStatus(task);
+  if (status === "in_progress") return OneDarkPro.syntax.yellow;
+  if (status === "blocked") return OneDarkPro.syntax.red;
+  if (status === "completed") return OneDarkPro.syntax.green;
+  return OneDarkPro.syntax.cyan;
+}
+
+export function WorktreeSidebar({
+  width,
+  height,
+  worktrees,
+  tasksPerWorktree,
+  activeWorktreePath,
+  focused,
+  selectedIndex,
+  expandedPaths,
+  onSelect,
+  onCreateNew,
+  onNavigate,
+  onToggleExpand,
+}: WorktreeSidebarProps) {
+  const flatItems = buildFlatList(worktrees, expandedPaths, tasksPerWorktree);
+
+  const truncate = (text: string, maxLen: number) => {
+    return text.length > maxLen ? `${text.substring(0, maxLen - 1)}…` : text;
+  };
+
+  // Keyboard handling when sidebar is focused
+  useKeyboard((event) => {
+    if (!focused) return;
+
+    if (event.name === "up" || event.sequence === "k") {
+      onNavigate(Math.max(0, selectedIndex - 1));
+      return;
+    }
+    if (event.name === "down" || event.sequence === "j") {
+      onNavigate(Math.min(flatItems.length - 1, selectedIndex + 1));
+      return;
+    }
+    if (event.name === "return") {
+      const item = flatItems[selectedIndex];
+      if (!item) return;
+      if (item.type === "worktree" && item.worktreePath) {
+        onSelect(item.worktreePath);
+      } else if (item.type === "new-button") {
+        onCreateNew();
+      }
+      return;
+    }
+    if (event.sequence === " ") {
+      const item = flatItems[selectedIndex];
+      if (item?.type === "worktree" && item.worktreePath) {
+        onToggleExpand(item.worktreePath);
+      }
+      return;
+    }
+    if (event.sequence === "n") {
+      onCreateNew();
+      return;
+    }
+  });
+
+  // Calculate visible items based on height (logo takes ~5 rows)
+  const headerHeight = 5;
+  const maxVisibleItems = Math.max(height - headerHeight, 1);
+
+  // Scroll window around selectedIndex
+  let scrollOffset = 0;
+  if (selectedIndex >= scrollOffset + maxVisibleItems) {
+    scrollOffset = selectedIndex - maxVisibleItems + 1;
+  }
+  if (selectedIndex < scrollOffset) {
+    scrollOffset = selectedIndex;
+  }
+
+  const visibleItems = flatItems.slice(
+    scrollOffset,
+    scrollOffset + maxVisibleItems,
+  );
+
+  return (
+    <box
+      width={width}
+      height={height}
+      backgroundColor={OneDarkPro.background.secondary}
+      paddingLeft={1}
+      paddingTop={1}
+      paddingRight={1}
+      flexDirection="column"
+      borderStyle="single"
+      borderColor={focused ? OneDarkPro.syntax.blue : OneDarkPro.ui.border}
+    >
+      {/* Header */}
+      <box flexDirection="column" marginBottom={1}>
+        <text fg={OneDarkPro.syntax.red}>{"█▀▀ █   █ █ █ █▀▀"}</text>
+        <text fg={OneDarkPro.syntax.red}>{"█   █   █ ▀▄▀ █▀▀"}</text>
+        <text fg={OneDarkPro.syntax.red}>{"▀▀▀ ▀▀▀ ▀  ▀  ▀▀▀"}</text>
+      </box>
+
+      {/* Worktree list */}
+      {visibleItems.map((item, i) => {
+        const globalIndex = scrollOffset + i;
+        const isSelected = focused && globalIndex === selectedIndex;
+        const isActive =
+          item.type === "worktree" && item.worktreePath === activeWorktreePath;
+
+        if (item.type === "worktree") {
+          const isExpanded = item.worktreePath
+            ? expandedPaths.has(item.worktreePath)
+            : false;
+          const taskCount = item.worktreePath
+            ? (tasksPerWorktree.get(item.worktreePath)?.length ?? 0)
+            : 0;
+          const chevron = taskCount > 0 ? (isExpanded ? "▾" : "▸") : " ";
+
+          return (
+            <box
+              key={`wt-${globalIndex}`}
+              flexDirection="row"
+              backgroundColor={
+                isSelected ? OneDarkPro.background.highlight : undefined
+              }
+            >
+              <text fg={isActive ? OneDarkPro.syntax.green : OneDarkPro.foreground.muted}>
+                {chevron}{" "}
+              </text>
+              <text
+                fg={
+                  isActive
+                    ? OneDarkPro.syntax.green
+                    : OneDarkPro.foreground.primary
+                }
+                bold={isActive}
+              >
+                {truncate(item.label, width - 5)}
+              </text>
+            </box>
+          );
+        }
+
+        if (item.type === "task" && item.task) {
+          return (
+            <box
+              key={`task-${globalIndex}`}
+              flexDirection="row"
+              paddingLeft={2}
+              backgroundColor={
+                isSelected ? OneDarkPro.background.highlight : undefined
+              }
+            >
+              <text fg={getStatusColor(item.task)}>
+                {getStatusIcon(item.task)}{" "}
+              </text>
+              <text fg={OneDarkPro.foreground.muted}>
+                {truncate(item.label, width - 7)}
+              </text>
+            </box>
+          );
+        }
+
+        if (item.type === "new-button") {
+          return (
+            <box
+              key="new-button"
+              flexDirection="row"
+              marginTop={1}
+              backgroundColor={
+                isSelected ? OneDarkPro.background.highlight : undefined
+              }
+            >
+              <text fg={OneDarkPro.syntax.green}>[+] </text>
+              <text fg={OneDarkPro.foreground.muted}>{item.label}</text>
+            </box>
+          );
+        }
+
+        return null;
+      })}
+
+      {/* Scroll indicator */}
+      {flatItems.length > maxVisibleItems && (
+        <text fg={OneDarkPro.foreground.comment} marginTop={0}>
+          {scrollOffset > 0 ? "↑ " : "  "}
+          {scrollOffset + maxVisibleItems < flatItems.length ? "↓" : " "}
+        </text>
+      )}
+    </box>
+  );
+}

--- a/apps/tui/src/hooks/useChatManager.ts
+++ b/apps/tui/src/hooks/useChatManager.ts
@@ -1,0 +1,1006 @@
+/**
+ * useChatManager Hook
+ *
+ * Top-level multi-chat state manager for the Conductor-like TUI layout.
+ * Manages multiple worktrees, each with multiple chat tabs.
+ * Each chat gets its own CliManager instance and XState machine actor.
+ */
+
+import { useQueryClient } from "@tanstack/react-query";
+import { createActor } from "xstate";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Effect, Runtime } from "effect";
+import { CliManager, type CliManagerOptions } from "../services/CliManager";
+import { ConversationWatcher } from "../services/ConversationWatcher";
+import { WorktreeService } from "../services/WorktreeService";
+import type { BuildConfig } from "../services/prompts";
+import { PromptService, PromptServiceLive } from "../services/prompts";
+import { SessionMetadataService } from "../services/SessionMetadataService";
+import { createChatMachine, type ChatMachineContext } from "../machines/chatMachine";
+import type {
+  ChatContext,
+  FocusZone,
+  OutputLine,
+  QuestionData,
+  Session,
+  WorktreeContext,
+} from "../types";
+import { loadCommand } from "../utils/command-loader";
+import { debugLog } from "../utils/debug-logger";
+import { taskQueryKeys } from "./useTaskQueries";
+
+// Unique ID generator
+let nextChatId = 0;
+function generateChatId(): string {
+  nextChatId += 1;
+  return `chat-${Date.now()}-${nextChatId}`;
+}
+
+export interface ChatManagerState {
+  // Worktree state
+  worktrees: WorktreeContext[];
+  activeWorktreePath: string | null;
+
+  // Active chat derived state
+  activeChat: ChatContext | null;
+  activeChatId: string | null;
+
+  // Focus
+  focusZone: FocusZone;
+
+  // Convenience derived state for the active chat
+  currentOutputLines: OutputLine[];
+  currentPendingQuestion: QuestionData | null;
+  currentMode: "none" | "plan" | "build" | "review";
+  currentIsRunning: boolean;
+
+  // Sessions (Linear issues)
+  activeSession: Session | null;
+
+  // Actions
+  selectWorktree: (path: string) => void;
+  createChat: (worktreePath?: string, mode?: "plan" | "build" | "review") => void;
+  selectChat: (chatId: string) => void;
+  closeChat: (chatId: string) => void;
+  executeCommand: (cmd: string) => void;
+  sendMessage: (msg: string) => void;
+  handleQuestionAnswer: (answers: Record<string, string>) => void;
+  interrupt: () => void;
+  cycleMode: () => void;
+  setFocusZone: (zone: FocusZone) => void;
+  cycleFocusZone: () => void;
+  setActiveSession: (session: Session | null) => void;
+  cleanup: () => void;
+}
+
+export function useChatManager(
+  mainWorkspaceRoot: string,
+  issueTracker?: "linear" | "beads" | null,
+): ChatManagerState {
+  const queryClient = useQueryClient();
+
+  // Core state
+  const [worktrees, setWorktrees] = useState<WorktreeContext[]>(() => [
+    {
+      path: mainWorkspaceRoot,
+      branch: "main",
+      isMain: true,
+      chats: [],
+      activeChatId: null,
+    },
+  ]);
+  const [activeWorktreePath, setActiveWorktreePath] = useState<string | null>(
+    mainWorkspaceRoot,
+  );
+  const [focusZone, setFocusZone] = useState<FocusZone>("main");
+  const [activeSession, setActiveSession] = useState<Session | null>(null);
+
+  // Per-chat resources
+  const cliManagers = useRef<Map<string, CliManager>>(new Map());
+  const chatActors = useRef<
+    Map<string, ReturnType<typeof createActor<ReturnType<typeof createChatMachine>>>>
+  >(new Map());
+  const conversationWatchers = useRef<Map<string, ConversationWatcher>>(new Map());
+  const seenQuestionIds = useRef<Map<string, Set<string>>>(new Map());
+
+  // Build loop tracking per-chat
+  const buildLoopState = useRef<
+    Map<
+      string,
+      {
+        iteration: number;
+        maxIterations: number;
+        isIterating: boolean;
+        lastCompletionMarker: "task-complete" | "all-tasks-complete" | null;
+      }
+    >
+  >(new Map());
+
+  // Refs for latest state in closures
+  const activeSessionRef = useRef(activeSession);
+  activeSessionRef.current = activeSession;
+  const worktreesRef = useRef(worktrees);
+  worktreesRef.current = worktrees;
+
+  // Derived: active worktree
+  const activeWorktree = useMemo(
+    () => worktrees.find((w) => w.path === activeWorktreePath) ?? null,
+    [worktrees, activeWorktreePath],
+  );
+
+  // Derived: active chat
+  const activeChatId = activeWorktree?.activeChatId ?? null;
+  const activeChat = useMemo(() => {
+    if (!activeWorktree || !activeChatId) return null;
+    return activeWorktree.chats.find((c) => c.id === activeChatId) ?? null;
+  }, [activeWorktree, activeChatId]);
+
+  // Derived: current chat state
+  const currentOutputLines = activeChat?.outputLines ?? [];
+  const currentPendingQuestion = activeChat?.pendingQuestion ?? null;
+  const currentMode = activeChat?.mode ?? "none";
+  const currentIsRunning = activeChat?.isRunning ?? false;
+
+  // Helper to update a specific chat's state
+  const updateChat = useCallback(
+    (chatId: string, updater: (chat: ChatContext) => ChatContext) => {
+      setWorktrees((prev) =>
+        prev.map((wt) => ({
+          ...wt,
+          chats: wt.chats.map((c) => (c.id === chatId ? updater(c) : c)),
+        })),
+      );
+    },
+    [],
+  );
+
+  // Helper to add output line to a chat
+  const addOutputToChat = useCallback(
+    (chatId: string, line: OutputLine) => {
+      updateChat(chatId, (c) => ({
+        ...c,
+        outputLines: [...c.outputLines, line],
+      }));
+    },
+    [updateChat],
+  );
+
+  // Helper to add system message
+  const addSystemMessage = useCallback(
+    (chatId: string, text: string) => {
+      addOutputToChat(chatId, { text, type: "system" });
+    },
+    [addOutputToChat],
+  );
+
+  /**
+   * Initialize a CliManager for a chat and wire up events
+   */
+  const initCliManager = useCallback(
+    (chatId: string) => {
+      const cli = new CliManager();
+      cliManagers.current.set(chatId, cli);
+      seenQuestionIds.current.set(chatId, new Set());
+
+      // Route output events to the specific chat
+      cli.on("output", (line: OutputLine) => {
+        if (line.type === "question" && line.question) {
+          const seen = seenQuestionIds.current.get(chatId);
+          const qid = line.question.toolUseID;
+          const hasQuestions = line.question.questions.length > 0;
+
+          if (seen?.has(qid) && hasQuestions) {
+            // Override empty question with complete data
+            updateChat(chatId, (c) => ({
+              ...c,
+              pendingQuestion:
+                c.pendingQuestion?.toolUseID === qid
+                  ? line.question!
+                  : c.pendingQuestion,
+            }));
+          } else if (!seen?.has(qid)) {
+            if (hasQuestions) seen?.add(qid);
+            updateChat(chatId, (c) => {
+              if (c.pendingQuestion) {
+                return {
+                  ...c,
+                  questionQueue: [...c.questionQueue, line.question!],
+                };
+              }
+              return { ...c, pendingQuestion: line.question! };
+            });
+          }
+        }
+
+        addOutputToChat(chatId, line);
+      });
+
+      cli.on("complete", () => {
+        const loop = buildLoopState.current.get(chatId);
+        if (loop?.isIterating) {
+          if (loop.lastCompletionMarker === "task-complete") {
+            const nextIteration = loop.iteration + 1;
+            if (nextIteration > loop.maxIterations) {
+              loop.isIterating = false;
+              updateChat(chatId, (c) => ({
+                ...c,
+                isRunning: false,
+                pendingQuestion: null,
+                questionQueue: [],
+              }));
+              addSystemMessage(
+                chatId,
+                `Build loop reached max iterations (${loop.maxIterations}). Stopping.`,
+              );
+              return;
+            }
+
+            updateChat(chatId, (c) => ({ ...c, isRunning: false }));
+            addSystemMessage(
+              chatId,
+              `Task complete. Starting iteration ${nextIteration}/${loop.maxIterations}...`,
+            );
+
+            setTimeout(() => {
+              startBuildIteration(chatId, nextIteration);
+            }, 1500);
+            return;
+          }
+
+          if (loop.lastCompletionMarker === "all-tasks-complete") {
+            loop.isIterating = false;
+            updateChat(chatId, (c) => ({
+              ...c,
+              isRunning: false,
+              pendingQuestion: null,
+              questionQueue: [],
+            }));
+            addSystemMessage(chatId, "All tasks complete. Build loop finished.");
+            return;
+          }
+
+          // No marker
+          loop.isIterating = false;
+          updateChat(chatId, (c) => ({
+            ...c,
+            isRunning: false,
+            pendingQuestion: null,
+            questionQueue: [],
+          }));
+          addSystemMessage(
+            chatId,
+            "Agent finished without completion marker. Build loop stopped.",
+          );
+          return;
+        }
+
+        updateChat(chatId, (c) => ({
+          ...c,
+          isRunning: false,
+          pendingQuestion: null,
+          questionQueue: [],
+        }));
+        seenQuestionIds.current.get(chatId)?.clear();
+      });
+
+      cli.on("killed", () => {
+        updateChat(chatId, (c) => ({
+          ...c,
+          isRunning: false,
+          pendingQuestion: null,
+          questionQueue: [],
+        }));
+      });
+
+      cli.on("task-complete", () => {
+        const loop = buildLoopState.current.get(chatId);
+        if (loop) loop.lastCompletionMarker = "task-complete";
+      });
+
+      cli.on("all-tasks-complete", () => {
+        const loop = buildLoopState.current.get(chatId);
+        if (loop) loop.lastCompletionMarker = "all-tasks-complete";
+      });
+
+      return cli;
+    },
+    [updateChat, addOutputToChat, addSystemMessage],
+  );
+
+  /**
+   * Start a build iteration for a specific chat
+   */
+  const startBuildIteration = useCallback(
+    async (chatId: string, iteration: number) => {
+      const cli = cliManagers.current.get(chatId);
+      if (!cli) return;
+
+      const loop = buildLoopState.current.get(chatId);
+      if (!loop) return;
+
+      loop.iteration = iteration;
+      loop.lastCompletionMarker = null;
+
+      // Find the chat's worktree
+      const chat = worktreesRef.current
+        .flatMap((w) => w.chats)
+        .find((c) => c.id === chatId);
+      if (!chat) return;
+
+      const effectiveWorkspaceRoot = chat.worktreePath;
+      const currentSession = activeSessionRef.current;
+      const epicId = currentSession?.linearData?.id;
+      const epicIdentifier = currentSession?.linearData?.identifier;
+
+      const buildConfig: BuildConfig = {
+        workspaceRoot: effectiveWorkspaceRoot,
+        mode: "build",
+        issueTracker: issueTracker ?? undefined,
+        epicId,
+        epicIdentifier,
+        iteration,
+        maxIterations: loop.maxIterations,
+      };
+
+      let systemPrompt: string;
+      try {
+        const promptProgram = Effect.gen(function* () {
+          const promptService = yield* PromptService;
+          return yield* promptService.buildPrompt(buildConfig);
+        });
+        systemPrompt = await Runtime.runPromise(Runtime.defaultRuntime)(
+          promptProgram.pipe(Effect.provide(PromptServiceLive)),
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        addSystemMessage(
+          chatId,
+          `Failed to build prompt for iteration ${iteration}: ${msg}`,
+        );
+        loop.isIterating = false;
+        updateChat(chatId, (c) => ({ ...c, isRunning: false }));
+        return;
+      }
+
+      cli.clear();
+      updateChat(chatId, (c) => ({
+        ...c,
+        outputLines: [],
+        isRunning: true,
+      }));
+
+      const command = loadCommand("build", effectiveWorkspaceRoot);
+      const commandMeta = command?.metadata;
+
+      addSystemMessage(
+        chatId,
+        `Starting iteration ${iteration}/${loop.maxIterations}...`,
+      );
+
+      cli
+        .execute(
+          `Continue with the next task. This is iteration ${iteration} of ${loop.maxIterations}.`,
+          {
+            workspaceRoot: effectiveWorkspaceRoot,
+            model: commandMeta?.model,
+            systemPrompt,
+            mode: "build",
+            allowedTools: commandMeta?.allowedTools,
+            disallowedTools: commandMeta?.deniedTools,
+            epicId,
+            epicIdentifier,
+          },
+        )
+        .catch((error: Error) => {
+          addSystemMessage(
+            chatId,
+            `Iteration ${iteration} error: ${error.message}`,
+          );
+          loop.isIterating = false;
+          updateChat(chatId, (c) => ({ ...c, isRunning: false }));
+        });
+    },
+    [issueTracker, updateChat, addSystemMessage],
+  );
+
+  /**
+   * Start execution in a specific chat
+   */
+  const startExecution = useCallback(
+    async (
+      chatId: string,
+      prompt: string,
+      mode: "plan" | "build" | "review",
+      userMessage?: string,
+      continuingSession = false,
+      resumeSessionId?: string,
+    ) => {
+      const cli = cliManagers.current.get(chatId);
+      if (!cli) return;
+
+      const chat = worktreesRef.current
+        .flatMap((w) => w.chats)
+        .find((c) => c.id === chatId);
+      if (!chat) return;
+
+      if (!continuingSession && !resumeSessionId) {
+        updateChat(chatId, (c) => ({ ...c, outputLines: [] }));
+        cli.clear();
+      }
+
+      if (userMessage) {
+        addOutputToChat(chatId, { text: userMessage, type: "user" });
+      }
+
+      updateChat(chatId, (c) => ({
+        ...c,
+        isRunning: true,
+        mode,
+      }));
+
+      const effectiveWorkspaceRoot = chat.worktreePath;
+      const epicId = activeSession?.linearData?.id;
+      const epicIdentifier = activeSession?.linearData?.identifier;
+
+      // Build system prompt
+      const buildConfig: BuildConfig = {
+        workspaceRoot: effectiveWorkspaceRoot,
+        mode,
+        issueTracker: issueTracker ?? undefined,
+        epicId,
+        epicIdentifier,
+      };
+
+      let systemPrompt: string;
+      try {
+        const promptProgram = Effect.gen(function* () {
+          const promptService = yield* PromptService;
+          return yield* promptService.buildPrompt(buildConfig);
+        });
+        systemPrompt = await Runtime.runPromise(Runtime.defaultRuntime)(
+          promptProgram.pipe(Effect.provide(PromptServiceLive)),
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        addSystemMessage(chatId, `Failed to build prompt: ${msg}`);
+        updateChat(chatId, (c) => ({ ...c, isRunning: false }));
+        return;
+      }
+
+      const command = loadCommand(mode, effectiveWorkspaceRoot);
+      const commandMeta = command?.metadata;
+
+      cli
+        .execute(prompt, {
+          workspaceRoot: effectiveWorkspaceRoot,
+          model: commandMeta?.model,
+          systemPrompt,
+          mode,
+          resumeSessionId,
+          allowedTools: commandMeta?.allowedTools,
+          disallowedTools: commandMeta?.deniedTools,
+          epicId,
+          epicIdentifier,
+        })
+        .catch((error: Error) => {
+          addSystemMessage(chatId, `Execution error: ${error.message}`);
+          updateChat(chatId, (c) => ({ ...c, isRunning: false }));
+        });
+    },
+    [
+      activeSession,
+      issueTracker,
+      updateChat,
+      addOutputToChat,
+      addSystemMessage,
+    ],
+  );
+
+  // ── Actions ──
+
+  const selectWorktree = useCallback((path: string) => {
+    setActiveWorktreePath(path);
+  }, []);
+
+  const createChat = useCallback(
+    (worktreePath?: string, mode?: "plan" | "build" | "review") => {
+      let targetPath = worktreePath || activeWorktreePath;
+
+      // If no specific worktree and the active one is main, create a standalone worktree
+      if (!worktreePath) {
+        const activeWt = worktreesRef.current.find(
+          (w) => w.path === activeWorktreePath,
+        );
+        if (activeWt?.isMain) {
+          const result = WorktreeService.createStandaloneWorktree(mainWorkspaceRoot);
+          if (result.success && result.metadata) {
+            targetPath = result.metadata.worktreePath;
+
+            // Add the new worktree to state
+            const newWt: WorktreeContext = {
+              path: result.metadata.worktreePath,
+              branch: result.metadata.branchName,
+              isMain: false,
+              chats: [],
+              activeChatId: null,
+            };
+
+            setWorktrees((prev) => [...prev, newWt]);
+            setActiveWorktreePath(targetPath);
+
+            // Invalidate worktree list
+            queryClient.invalidateQueries({ queryKey: ["worktrees"] });
+          } else {
+            // Fallback: create chat in main worktree
+            targetPath = mainWorkspaceRoot;
+          }
+        }
+      }
+
+      if (!targetPath) targetPath = mainWorkspaceRoot;
+
+      const chatId = generateChatId();
+      const newChat: ChatContext = {
+        id: chatId,
+        worktreePath: targetPath,
+        mode: mode || "none",
+        label: "New chat",
+        outputLines: [],
+        pendingQuestion: null,
+        questionQueue: [],
+        isRunning: false,
+        createdAt: new Date(),
+      };
+
+      // Initialize CliManager for this chat
+      initCliManager(chatId);
+
+      // Add chat to the target worktree
+      setWorktrees((prev) =>
+        prev.map((wt) => {
+          if (wt.path === targetPath) {
+            return {
+              ...wt,
+              chats: [...wt.chats, newChat],
+              activeChatId: chatId,
+            };
+          }
+          return wt;
+        }),
+      );
+
+      // Ensure the target worktree is active
+      setActiveWorktreePath(targetPath);
+
+      debugLog("useChatManager", "Created chat", {
+        chatId,
+        worktreePath: targetPath,
+        mode,
+      });
+    },
+    [activeWorktreePath, mainWorkspaceRoot, initCliManager, queryClient],
+  );
+
+  const selectChat = useCallback(
+    (chatId: string) => {
+      setWorktrees((prev) =>
+        prev.map((wt) => {
+          if (wt.chats.some((c) => c.id === chatId)) {
+            return { ...wt, activeChatId: chatId };
+          }
+          return wt;
+        }),
+      );
+    },
+    [],
+  );
+
+  const closeChat = useCallback(
+    (chatId: string) => {
+      // Kill the CliManager
+      const cli = cliManagers.current.get(chatId);
+      if (cli) {
+        cli.kill();
+        cli.removeAllListeners();
+        cliManagers.current.delete(chatId);
+      }
+
+      // Clean up other resources
+      seenQuestionIds.current.delete(chatId);
+      buildLoopState.current.delete(chatId);
+
+      const watcher = conversationWatchers.current.get(chatId);
+      if (watcher) {
+        watcher.stop();
+        watcher.removeAllListeners();
+        conversationWatchers.current.delete(chatId);
+      }
+
+      // Remove from state and select next available chat
+      setWorktrees((prev) =>
+        prev.map((wt) => {
+          const idx = wt.chats.findIndex((c) => c.id === chatId);
+          if (idx === -1) return wt;
+
+          const newChats = wt.chats.filter((c) => c.id !== chatId);
+          let newActiveChatId = wt.activeChatId;
+
+          if (wt.activeChatId === chatId) {
+            // Select the previous tab, or the next one, or null
+            const newIdx = Math.min(idx, newChats.length - 1);
+            newActiveChatId = newIdx >= 0 ? newChats[newIdx]!.id : null;
+          }
+
+          return {
+            ...wt,
+            chats: newChats,
+            activeChatId: newActiveChatId,
+          };
+        }),
+      );
+    },
+    [],
+  );
+
+  const executeCommand = useCallback(
+    (cmd: string) => {
+      if (!cmd.trim()) return;
+
+      const currentChatId = activeChatId;
+      if (!currentChatId) {
+        // Auto-create a chat if none exists
+        createChat();
+        // The command will be re-issued after the chat is created
+        return;
+      }
+
+      const chat = worktreesRef.current
+        .flatMap((w) => w.chats)
+        .find((c) => c.id === currentChatId);
+      if (!chat) return;
+
+      const isSlashCommand = cmd.startsWith("/");
+      const inActiveMode = chat.mode !== "none";
+
+      // If in active mode and not a slash command, continue conversation
+      if (inActiveMode && !isSlashCommand) {
+        if (chat.isRunning) {
+          addSystemMessage(
+            currentChatId,
+            "Still processing... please wait for the current turn to complete.",
+          );
+          return;
+        }
+
+        startExecution(
+          currentChatId,
+          cmd,
+          chat.mode as "plan" | "build" | "review",
+          `> ${cmd}`,
+          true,
+        );
+        return;
+      }
+
+      if (isSlashCommand) {
+        handleSlashCommand(currentChatId, cmd);
+        return;
+      }
+
+      addSystemMessage(
+        currentChatId,
+        "No process running. Use /plan or /build to start, or press Shift+Tab to set a mode.",
+      );
+    },
+    [activeChatId, createChat, startExecution, addSystemMessage],
+  );
+
+  const handleSlashCommand = useCallback(
+    (chatId: string, cmd: string) => {
+      const parts = cmd.split(" ");
+      const command = parts[0]!.toLowerCase();
+      const args = parts.slice(1).join(" ").trim();
+
+      switch (command) {
+        case "/plan": {
+          const resumeMatch = args.match(/--resume=([a-f0-9-]+)/);
+          const resumeSessionId = resumeMatch ? resumeMatch[1] : undefined;
+          const cleanArgs = args.replace(/--resume=[a-f0-9-]+\s*/, "").trim();
+
+          if (resumeSessionId) {
+            addSystemMessage(
+              chatId,
+              `Resuming conversation: ${resumeSessionId.substring(0, 8)}...`,
+            );
+            startExecution(
+              chatId,
+              cleanArgs || "Continue the conversation",
+              "plan",
+              `> ${cleanArgs || "Continue the conversation"}`,
+              false,
+              resumeSessionId,
+            );
+            break;
+          }
+
+          const prompt = cleanArgs || "Create a plan for the current task";
+          startExecution(chatId, prompt, "plan", cleanArgs ? `> ${cleanArgs}` : undefined);
+          break;
+        }
+
+        case "/build": {
+          const buildResumeMatch = args.match(/--resume=([a-f0-9-]+)/);
+          const buildResumeSessionId = buildResumeMatch ? buildResumeMatch[1] : undefined;
+          const buildCleanArgs = args.replace(/--resume=[a-f0-9-]+\s*/, "").trim();
+
+          if (buildResumeSessionId) {
+            addSystemMessage(
+              chatId,
+              `Resuming build: ${buildResumeSessionId.substring(0, 8)}...`,
+            );
+            startExecution(
+              chatId,
+              buildCleanArgs || "Continue the build",
+              "build",
+              `> ${buildCleanArgs || "Continue the build"}`,
+              false,
+              buildResumeSessionId,
+            );
+            break;
+          }
+
+          const maxIterMatch = buildCleanArgs.match(/--max-iterations=(\d+)/);
+          const maxIter = maxIterMatch ? parseInt(maxIterMatch[1]!, 10) : 10;
+          const buildPromptArgs = buildCleanArgs
+            .replace(/--max-iterations=\d+\s*/, "")
+            .trim();
+
+          buildLoopState.current.set(chatId, {
+            iteration: 1,
+            maxIterations: maxIter,
+            isIterating: true,
+            lastCompletionMarker: null,
+          });
+
+          const buildPrompt = buildPromptArgs || "Execute the plan";
+          startExecution(
+            chatId,
+            buildPrompt,
+            "build",
+            buildPromptArgs ? `> ${buildPromptArgs}` : undefined,
+          );
+          break;
+        }
+
+        case "/exit": {
+          const chat = worktreesRef.current
+            .flatMap((w) => w.chats)
+            .find((c) => c.id === chatId);
+          if (chat && chat.mode !== "none") {
+            const cli = cliManagers.current.get(chatId);
+            cli?.kill();
+            cli?.clear();
+            updateChat(chatId, (c) => ({
+              ...c,
+              mode: "none",
+              isRunning: false,
+              pendingQuestion: null,
+              questionQueue: [],
+            }));
+            addSystemMessage(chatId, `Exited ${chat.mode} mode`);
+          } else {
+            addSystemMessage(chatId, "Not currently in any mode");
+          }
+          break;
+        }
+
+        case "/clear":
+          updateChat(chatId, (c) => ({ ...c, outputLines: [] }));
+          break;
+
+        case "/cancel":
+        case "/stop": {
+          const cli = cliManagers.current.get(chatId);
+          if (cli) {
+            cli.interrupt();
+            addSystemMessage(chatId, "Execution interrupted");
+          }
+          const loop = buildLoopState.current.get(chatId);
+          if (loop) loop.isIterating = false;
+          updateChat(chatId, (c) => ({
+            ...c,
+            isRunning: false,
+            pendingQuestion: null,
+            questionQueue: [],
+          }));
+          break;
+        }
+
+        case "/help":
+          addSystemMessage(
+            chatId,
+            [
+              "Clive TUI Commands:",
+              "",
+              "/plan [prompt]  - Create a plan",
+              "/build [prompt] - Execute a task",
+              "/clear         - Clear output",
+              "/cancel        - Stop execution",
+              "/help          - Show this help",
+              "",
+              "Shortcuts:",
+              "Shift+Tab      - Cycle mode (plan/build/review)",
+              "Tab            - Cycle focus zone",
+              "Ctrl+1-9       - Direct tab selection",
+            ].join("\n"),
+          );
+          break;
+
+        default:
+          addSystemMessage(chatId, `Unknown command: ${command}`);
+      }
+    },
+    [startExecution, updateChat, addSystemMessage],
+  );
+
+  const sendMessage = useCallback(
+    (msg: string) => {
+      if (!activeChatId) return;
+      const cli = cliManagers.current.get(activeChatId);
+      if (!cli) return;
+      cli.sendMessageToAgent(msg);
+      addOutputToChat(activeChatId, { text: `> ${msg}`, type: "user" });
+    },
+    [activeChatId, addOutputToChat],
+  );
+
+  const handleQuestionAnswer = useCallback(
+    (answers: Record<string, string>) => {
+      if (!activeChatId) return;
+
+      const chat = worktreesRef.current
+        .flatMap((w) => w.chats)
+        .find((c) => c.id === activeChatId);
+      if (!chat?.pendingQuestion) return;
+
+      const toolUseID = chat.pendingQuestion.toolUseID;
+
+      // Handle internal questions
+      if (toolUseID.startsWith("internal:")) {
+        updateChat(activeChatId, (c) => {
+          const nextQuestion = c.questionQueue[0] ?? null;
+          return {
+            ...c,
+            pendingQuestion: nextQuestion,
+            questionQueue: c.questionQueue.slice(nextQuestion ? 1 : 0),
+          };
+        });
+
+        if (toolUseID.startsWith("internal:review-transition")) {
+          const answer = Object.values(answers)[0];
+          if (answer === "Start Build") {
+            setTimeout(() => executeCommand("/build"), 100);
+          }
+        }
+        return;
+      }
+
+      const cli = cliManagers.current.get(activeChatId);
+      if (!cli) return;
+
+      cli.sendToolResult(toolUseID, JSON.stringify(answers));
+
+      updateChat(activeChatId, (c) => {
+        const nextQuestion = c.questionQueue[0] ?? null;
+        return {
+          ...c,
+          pendingQuestion: nextQuestion,
+          questionQueue: c.questionQueue.slice(nextQuestion ? 1 : 0),
+        };
+      });
+    },
+    [activeChatId, updateChat, executeCommand],
+  );
+
+  const interrupt = useCallback(() => {
+    if (!activeChatId) return;
+    const cli = cliManagers.current.get(activeChatId);
+    if (cli) {
+      cli.interrupt();
+      addSystemMessage(activeChatId, "Execution interrupted");
+    }
+    const loop = buildLoopState.current.get(activeChatId);
+    if (loop) loop.isIterating = false;
+    updateChat(activeChatId, (c) => ({
+      ...c,
+      isRunning: false,
+      pendingQuestion: null,
+      questionQueue: [],
+    }));
+  }, [activeChatId, updateChat, addSystemMessage]);
+
+  const cycleMode = useCallback(() => {
+    if (!activeChatId) return;
+
+    const modeOrder: Array<"none" | "plan" | "build" | "review"> = [
+      "none",
+      "plan",
+      "build",
+      "review",
+    ];
+
+    updateChat(activeChatId, (c) => {
+      const currentIdx = modeOrder.indexOf(c.mode);
+      const nextMode = modeOrder[(currentIdx + 1) % modeOrder.length]!;
+
+      if (c.isRunning) {
+        // Don't actually change mode while running, just warn
+        return c;
+      }
+
+      return { ...c, mode: nextMode };
+    });
+
+    // Show feedback
+    const chat = worktreesRef.current
+      .flatMap((w) => w.chats)
+      .find((c) => c.id === activeChatId);
+    if (chat?.isRunning) {
+      addSystemMessage(activeChatId, "Cannot change mode while running");
+    }
+  }, [activeChatId, updateChat, addSystemMessage]);
+
+  const cycleFocusZone = useCallback(() => {
+    setFocusZone((prev) => {
+      const order: FocusZone[] = ["sidebar", "tabs", "main"];
+      const idx = order.indexOf(prev);
+      return order[(idx + 1) % order.length]!;
+    });
+  }, []);
+
+  const cleanup = useCallback(() => {
+    for (const [, cli] of cliManagers.current) {
+      cli.kill();
+      cli.removeAllListeners();
+    }
+    cliManagers.current.clear();
+
+    for (const [, watcher] of conversationWatchers.current) {
+      watcher.stop();
+      watcher.removeAllListeners();
+    }
+    conversationWatchers.current.clear();
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return cleanup;
+  }, [cleanup]);
+
+  return {
+    worktrees,
+    activeWorktreePath,
+    activeChat,
+    activeChatId,
+    focusZone,
+    currentOutputLines,
+    currentPendingQuestion,
+    currentMode,
+    currentIsRunning,
+    activeSession,
+
+    selectWorktree,
+    createChat,
+    selectChat,
+    closeChat,
+    executeCommand,
+    sendMessage,
+    handleQuestionAnswer,
+    interrupt,
+    cycleMode,
+    setFocusZone,
+    cycleFocusZone,
+    setActiveSession,
+    cleanup,
+  };
+}

--- a/apps/tui/src/hooks/useWorktreeList.ts
+++ b/apps/tui/src/hooks/useWorktreeList.ts
@@ -1,0 +1,25 @@
+/**
+ * useWorktreeList Hook
+ * React Query wrapper for WorktreeService.listWorktrees()
+ * Polls every 10 seconds to detect new/removed worktrees.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  type WorktreeInfo,
+  WorktreeService,
+} from "../services/WorktreeService";
+
+export const worktreeQueryKeys = {
+  all: ["worktrees"] as const,
+  list: (root: string) => ["worktrees", "list", root] as const,
+};
+
+export function useWorktreeList(mainWorkspaceRoot: string) {
+  return useQuery<WorktreeInfo[]>({
+    queryKey: worktreeQueryKeys.list(mainWorkspaceRoot),
+    queryFn: () => WorktreeService.listWorktrees(mainWorkspaceRoot),
+    refetchInterval: 10_000,
+    staleTime: 5_000,
+  });
+}

--- a/apps/tui/src/machines/chatMachine.ts
+++ b/apps/tui/src/machines/chatMachine.ts
@@ -1,0 +1,228 @@
+/**
+ * Per-Chat XState Machine
+ *
+ * Extracted from useAppState.ts. Each chat tab gets its own instance of this machine
+ * to manage CLI execution state, output lines, and question handling independently.
+ *
+ * States: idle → executing → waiting_for_answer
+ */
+
+import { assign, setup } from "xstate";
+import type { OutputLine, QuestionData } from "../types";
+
+export interface ChatMachineContext {
+  chatId: string;
+  outputLines: OutputLine[];
+  pendingQuestion: QuestionData | null;
+  questionQueue: QuestionData[];
+  mode: "none" | "plan" | "build" | "review";
+  agentSessionActive: boolean;
+}
+
+export type ChatMachineEvent =
+  | { type: "EXECUTE"; prompt: string; mode: "plan" | "build" | "review" }
+  | { type: "OUTPUT"; line: OutputLine }
+  | { type: "QUESTION"; question: QuestionData }
+  | { type: "ANSWER"; answers: Record<string, string> }
+  | { type: "COMPLETE" }
+  | { type: "INTERRUPT" }
+  | { type: "EXIT_MODE" }
+  | { type: "CLEAR" }
+  | { type: "MESSAGE"; content: string }
+  | { type: "SET_MODE"; mode: "none" | "plan" | "build" | "review" };
+
+export function createChatMachine(chatId: string) {
+  return setup({
+    types: {
+      context: {} as ChatMachineContext,
+      events: {} as ChatMachineEvent,
+    },
+    actions: {
+      updateOutput: assign({
+        outputLines: ({ context, event }) => {
+          if (event.type !== "OUTPUT") return context.outputLines;
+          return [...context.outputLines, event.line];
+        },
+      }),
+      setQuestion: assign({
+        pendingQuestion: ({ context, event }) => {
+          if (event.type !== "QUESTION") return context.pendingQuestion;
+
+          // Allow a complete question to replace an existing empty one with the
+          // same toolUseID (handles streaming parser edge cases)
+          if (
+            context.pendingQuestion &&
+            context.pendingQuestion.toolUseID === event.question.toolUseID &&
+            context.pendingQuestion.questions.length === 0 &&
+            event.question.questions.length > 0
+          ) {
+            return event.question;
+          }
+
+          return context.pendingQuestion || event.question;
+        },
+        questionQueue: ({ context, event }) => {
+          if (event.type !== "QUESTION") return context.questionQueue;
+
+          // Don't queue if this is replacing the current pending question
+          if (
+            context.pendingQuestion &&
+            context.pendingQuestion.toolUseID === event.question.toolUseID &&
+            context.pendingQuestion.questions.length === 0 &&
+            event.question.questions.length > 0
+          ) {
+            return context.questionQueue;
+          }
+
+          // If there's already a pending question, add new question to queue
+          if (context.pendingQuestion) {
+            return [...context.questionQueue, event.question];
+          }
+
+          return context.questionQueue;
+        },
+      }),
+      clearQuestion: assign({
+        pendingQuestion: ({ context }) => {
+          if (context.questionQueue.length > 0) {
+            return context.questionQueue[0]!;
+          }
+          return null;
+        },
+        questionQueue: ({ context }) => {
+          if (context.questionQueue.length > 0) {
+            return context.questionQueue.slice(1);
+          }
+          return [];
+        },
+      }),
+      clearOutput: assign({
+        outputLines: [],
+      }),
+      renderMessage: assign({
+        outputLines: ({ context, event }) => {
+          if (event.type !== "MESSAGE") return context.outputLines;
+          return [
+            ...context.outputLines,
+            { type: "user" as const, text: event.content },
+          ];
+        },
+      }),
+      setMode: assign({
+        mode: ({ event }) => {
+          if (event.type === "EXECUTE") return event.mode;
+          if (event.type === "SET_MODE") return event.mode;
+          return "none" as const;
+        },
+        agentSessionActive: ({ event }) => {
+          if (event.type === "SET_MODE") return false;
+          return true;
+        },
+      }),
+      clearMode: assign({
+        mode: "none" as const,
+        agentSessionActive: false,
+      }),
+      clearQuestionQueue: assign({
+        pendingQuestion: null,
+        questionQueue: [] as QuestionData[],
+      }),
+    },
+  }).createMachine({
+    id: `chat-${chatId}`,
+    initial: "idle",
+    context: {
+      chatId,
+      outputLines: [],
+      pendingQuestion: null,
+      questionQueue: [],
+      mode: "none",
+      agentSessionActive: false,
+    },
+    states: {
+      idle: {
+        on: {
+          EXECUTE: {
+            target: "executing",
+            actions: "setMode",
+          },
+          QUESTION: {
+            target: "waiting_for_answer",
+            actions: "setQuestion",
+          },
+          EXIT_MODE: {
+            actions: "clearMode",
+          },
+          SET_MODE: {
+            actions: "setMode",
+          },
+          CLEAR: {
+            actions: "clearOutput",
+          },
+          OUTPUT: {
+            actions: "updateOutput",
+          },
+        },
+      },
+      executing: {
+        on: {
+          OUTPUT: {
+            actions: "updateOutput",
+          },
+          QUESTION: {
+            target: "waiting_for_answer",
+            actions: "setQuestion",
+          },
+          COMPLETE: {
+            target: "idle",
+            actions: "clearQuestionQueue",
+          },
+          INTERRUPT: {
+            target: "idle",
+            actions: ["clearMode", "clearQuestionQueue"],
+          },
+          EXIT_MODE: {
+            target: "idle",
+            actions: ["clearMode", "clearQuestionQueue"],
+          },
+          MESSAGE: {
+            actions: "renderMessage",
+          },
+        },
+      },
+      waiting_for_answer: {
+        on: {
+          OUTPUT: {
+            actions: "updateOutput",
+          },
+          QUESTION: {
+            actions: "setQuestion",
+          },
+          ANSWER: [
+            {
+              target: "waiting_for_answer",
+              guard: ({ context }) => context.questionQueue.length > 0,
+              actions: "clearQuestion",
+            },
+            {
+              target: "executing",
+              actions: "clearQuestion",
+            },
+          ],
+          COMPLETE: {
+            target: "idle",
+            actions: "clearQuestionQueue",
+          },
+          INTERRUPT: {
+            target: "idle",
+            actions: ["clearQuestionQueue", "clearMode"],
+          },
+          EXIT_MODE: {
+            target: "idle",
+            actions: ["clearQuestionQueue", "clearMode"],
+          },
+        },
+      },
+    },
+  });
+}

--- a/apps/tui/src/types/index.ts
+++ b/apps/tui/src/types/index.ts
@@ -123,3 +123,38 @@ export interface Config {
   beads?: Record<string, unknown>;
   worker?: WorkerConfig;
 }
+
+/**
+ * Focus zone for keyboard navigation between sidebar, tabs, and main content.
+ */
+export type FocusZone = "sidebar" | "tabs" | "main";
+
+/**
+ * A single chat session within a worktree.
+ * Each chat has its own CliManager, output history, mode, and question state.
+ */
+export interface ChatContext {
+  id: string;
+  worktreePath: string;
+  sessionId?: string;
+  mode: "none" | "plan" | "build" | "review";
+  label: string;
+  outputLines: OutputLine[];
+  pendingQuestion: QuestionData | null;
+  questionQueue: QuestionData[];
+  isRunning: boolean;
+  createdAt: Date;
+}
+
+/**
+ * A worktree with its associated chats and epic context.
+ */
+export interface WorktreeContext {
+  path: string;
+  branch: string;
+  isMain: boolean;
+  epicId?: string;
+  epicIdentifier?: string;
+  chats: ChatContext[];
+  activeChatId: string | null;
+}


### PR DESCRIPTION
## Summary

- Adds a Conductor-style workspace manager layout with a worktree sidebar showing git worktrees and nested Linear tasks, multi-chat tabs with per-chat state machines, and Shift+Tab mode toggling (plan/build/review)
- Introduces `useChatManager` hook managing multi-chat lifecycle with independent CliManager instances per chat, focus zone cycling (sidebar → tabs → main via Tab), and auto worktree creation for new chats
- Extends `WorktreeService` with `listWorktrees()` and `createStandaloneWorktree()` for git worktree management, adds new components (`WorktreeSidebar`, `TabBar`, `ModeIndicator`), and refactors App.tsx to use the new Conductor layout while preserving worker mode as a separate code path

## Test plan

- [ ] Run `clive` in a repo with existing worktrees and verify sidebar shows all worktrees with correct branches
- [ ] Press `n` in sidebar to create a new worktree and verify a new tab opens
- [ ] Create 2+ chats and verify `h/l` in tabs zone switches between them with output changing
- [ ] Verify `Shift+Tab` cycles mode indicator in tab + input area
- [ ] Verify `Tab` moves focus highlight between sidebar → tabs → input
- [ ] Start `/build` and verify CLI executes in the worktree directory
- [ ] Resume a conversation and verify it finds the correct worktree